### PR TITLE
Add forecast API endpoints

### DIFF
--- a/api/forecast/today.html
+++ b/api/forecast/today.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <title>Vandaag voorspelling API</title>
+</head>
+<body>
+  <pre id="data"></pre>
+  <script>
+    (function() {
+      const now = new Date();
+      const dayOfWeek = now.getDay();
+      const hour = now.getHours();
+      const seed = dayOfWeek * 24 + hour;
+      const prediction = seed % 2 === 0 ? 'ja' : 'nee';
+      const output = {
+        "vraag": "Gaan Jasper & Pijke winnen?",
+        "voorspelling": prediction,
+        "moment": "today",
+        "timestamp": now.toISOString()
+      };
+      document.getElementById('data').textContent = JSON.stringify(output, null, 2);
+    })();
+  </script>
+</body>
+</html>

--- a/api/forecast/tomorrow.html
+++ b/api/forecast/tomorrow.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <title>Morgen voorspelling API</title>
+</head>
+<body>
+  <pre id="data"></pre>
+  <script>
+    (function() {
+      const now = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      const dayOfWeek = now.getDay();
+      const hour = now.getHours();
+      const seed = dayOfWeek * 24 + hour;
+      const prediction = seed % 2 === 0 ? 'ja' : 'nee';
+      const output = {
+        "vraag": "Gaan Jasper & Pijke winnen?",
+        "voorspelling": prediction,
+        "moment": "tomorrow",
+        "timestamp": now.toISOString()
+      };
+      document.getElementById('data').textContent = JSON.stringify(output, null, 2);
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add API endpoints under `/api/forecast/` for deterministic JSON

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68750b8a51b883258facee42e576bcea