### PR TITLE
Add separate forecast API pages

### DIFF
--- a/api/forecast/today/index.html
+++ b/api/forecast/today/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+<meta charset="UTF-8" />
+<title>Forecast API - Vandaag</title>
+</head>
+<body>
+<pre id="json">Generating forecast...</pre>
+<script>
+function getTodayKey() {
+  const today = new Date();
+  return today.toISOString().split('T')[0];
+}
+function getDailyHash(input) {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+function getDeterministicAnswer() {
+  const hash = getDailyHash(getTodayKey());
+  return hash % 2 === 0 ? 'Ja' : 'Nee';
+}
+function generateSingleSetScore(answer) {
+  const base = getDailyHash(getTodayKey() + '_set_prediction');
+  const outcomes = [
+    [6,0], [6,1], [6,2], [6,3], [6,4],
+    [7,5], [7,6]
+  ];
+  const index = base % outcomes.length;
+  let [scoreTeam1, scoreTeam2] = outcomes[index];
+  const pijkeJasperWin = (answer === 'Ja');
+  const scorePijkeJasper = pijkeJasperWin ? scoreTeam1 : scoreTeam2;
+  const scoreDaanKors = pijkeJasperWin ? scoreTeam2 : scoreTeam1;
+  let tiebreakDetails = null;
+  if ((scorePijkeJasper === 7 && scoreDaanKors === 6) ||
+      (scoreDaanKors === 7 && scorePijkeJasper === 6)) {
+    const tiebreakBase = getDailyHash(getTodayKey() + '_tiebreak_prediction');
+    const tiebreakPointsWinner = 7 + (tiebreakBase % 4);
+    let tiebreakPointsLoser;
+    if (tiebreakPointsWinner === 7) {
+      tiebreakPointsLoser = (tiebreakBase % 5);
+    } else {
+      tiebreakPointsLoser = tiebreakPointsWinner - 2;
+    }
+    tiebreakPointsLoser = Math.max(0, Math.min(tiebreakPointsLoser, tiebreakPointsWinner - 2));
+    tiebreakDetails = pijkeJasperWin
+      ? `${tiebreakPointsWinner}–${tiebreakPointsLoser}`
+      : `${tiebreakPointsLoser}–${tiebreakPointsWinner}`;
+  }
+  return { scoreA: scoreDaanKors, scoreB: scorePijkeJasper, tiebreak: tiebreakDetails };
+}
+function generatePrediction() {
+  const answer = getDeterministicAnswer();
+  const { scoreA, scoreB, tiebreak } = generateSingleSetScore(answer);
+  return { answer, scoreA, scoreB, tiebreak };
+}
+document.addEventListener('DOMContentLoaded', () => {
+  const pre = document.getElementById('json');
+  pre.textContent = JSON.stringify(generatePrediction(), null, 2);
+});
+</script>
+</body>
+</html>

--- a/api/forecast/tomorrow/index.html
+++ b/api/forecast/tomorrow/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+<meta charset="UTF-8" />
+<title>Forecast API - Morgen</title>
+</head>
+<body>
+<pre id="json">Generating forecast...</pre>
+<script>
+function getTomorrowKey() {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow.toISOString().split('T')[0];
+}
+function getDailyHash(input) {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+function getDeterministicAnswer() {
+  const hash = getDailyHash(getTomorrowKey());
+  return hash % 2 === 0 ? 'Ja' : 'Nee';
+}
+function generateSingleSetScore(answer) {
+  const base = getDailyHash(getTomorrowKey() + '_set_prediction');
+  const outcomes = [
+    [6,0], [6,1], [6,2], [6,3], [6,4],
+    [7,5], [7,6]
+  ];
+  const index = base % outcomes.length;
+  let [scoreTeam1, scoreTeam2] = outcomes[index];
+  const pijkeJasperWin = (answer === 'Ja');
+  const scorePijkeJasper = pijkeJasperWin ? scoreTeam1 : scoreTeam2;
+  const scoreDaanKors = pijkeJasperWin ? scoreTeam2 : scoreTeam1;
+  let tiebreakDetails = null;
+  if ((scorePijkeJasper === 7 && scoreDaanKors === 6) ||
+      (scoreDaanKors === 7 && scorePijkeJasper === 6)) {
+    const tiebreakBase = getDailyHash(getTomorrowKey() + '_tiebreak_prediction');
+    const tiebreakPointsWinner = 7 + (tiebreakBase % 4);
+    let tiebreakPointsLoser;
+    if (tiebreakPointsWinner === 7) {
+      tiebreakPointsLoser = (tiebreakBase % 5);
+    } else {
+      tiebreakPointsLoser = tiebreakPointsWinner - 2;
+    }
+    tiebreakPointsLoser = Math.max(0, Math.min(tiebreakPointsLoser, tiebreakPointsWinner - 2));
+    tiebreakDetails = pijkeJasperWin
+      ? `${tiebreakPointsWinner}–${tiebreakPointsLoser}`
+      : `${tiebreakPointsLoser}–${tiebreakPointsWinner}`;
+  }
+  return { scoreA: scoreDaanKors, scoreB: scorePijkeJasper, tiebreak: tiebreakDetails };
+}
+function generatePrediction() {
+  const answer = getDeterministicAnswer();
+  const { scoreA, scoreB, tiebreak } = generateSingleSetScore(answer);
+  return { answer, scoreA, scoreB, tiebreak };
+}
+document.addEventListener('DOMContentLoaded', () => {
+  const pre = document.getElementById('json');
+  pre.textContent = JSON.stringify(generatePrediction(), null, 2);
+});
+</script>
+</body>
+</html>

--- a/tomorrow.html
+++ b/tomorrow.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Gaan Jasper & Pijke morgen winnen?</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: 'Courier New', monospace;
+      background: linear-gradient(to bottom right, #fefcea, #f1da36);
+      color: #1f1f1f;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      min-height: 100vh;
+      text-align: center;
+      padding: 1.5rem;
+      overflow-y: auto;
+    }
+    h1 {
+      font-size: 2rem;
+      margin-bottom: 1rem;
+      text-shadow: 1px 1px #fff;
+    }
+    h2 { /* Standaard h2 styling */
+      font-size: 1.5rem;
+      margin-top: 2rem;
+      margin-bottom: 0.5rem;
+      color: #333;
+    }
+    .prediction-title { /* Specifieke class voor de voorspellingstitel */
+      font-size: 2.2rem; /* Groter dan standaard h2 */
+      margin-bottom: 1rem; /* Meer ruimte onder de titel */
+    }
+    .answer {
+      font-size: 5rem; /* Nog iets groter gemaakt */
+      font-weight: bold;
+      margin-bottom: 1.5rem;
+      animation: pop 0.6s ease;
+    }
+    .scoreboard {
+      display: flex;
+      flex-direction: column;
+      background: #2e2e2e;
+      padding: 1rem 1.5rem;
+      border-radius: 12px;
+      box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
+      margin-bottom: 1rem;
+      width: fit-content;
+      max-width: 90%;
+    }
+    .row-wrapper {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
+    }
+    .row-wrapper:last-child {
+      margin-bottom: 0;
+    }
+    .team-label {
+      color: #fff;
+      font-weight: bold;
+      width: 130px;
+      text-align: right;
+      font-size: 0.9rem;
+    }
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .bead {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: #facc15;
+      box-shadow: inset 0 0 3px #000;
+    }
+
+    /* Specifieke styling voor het voorspellingsscorebord */
+    #prediction_scoreboard .team-label {
+      font-size: 1.1rem; /* Grotere team labels */
+      width: 150px; /* Iets breder voor grotere tekst */
+    }
+    #prediction_scoreboard .bead {
+      width: 24px; /* Grotere kralen */
+      height: 24px;
+    }
+    #prediction_scoreboard .row {
+      gap: 8px; /* Iets meer ruimte tussen grotere kralen */
+    }
+    #prediction_scoreboard .row-wrapper {
+      gap: 1.2rem; /* Iets meer ruimte tussen label en kralenrij */
+      margin-bottom: 1rem; /* Meer ruimte tussen de rijen */
+    }
+
+
+    #tiebreak { /* Tiebreak tekst onder voorspelling */
+      font-size: 1.2rem; /* Grotere tiebreak tekst */
+      color: #333; /* Donkerder voor betere leesbaarheid */
+      margin-top: 0.8rem;
+    }
+    .latest-actual-result-text { /* Tekst boven daadwerkelijke uitslag */
+      font-size: 1rem;
+      color: #444;
+      text-align: center;
+      margin-top: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    .error-message {
+      color: red;
+      font-weight: bold;
+      margin-top: 1rem;
+    }
+    @keyframes pop {
+      0% { transform: scale(0.8); opacity: 0; }
+      100% { transform: scale(1); opacity: 1; }
+    }
+    #confetti-canvas {
+      position:fixed;
+      pointer-events:none;
+      top:0;
+      left:0;
+      width:100%;
+      height:100%;
+      z-index:999;
+    }
+  </style>
+</head>
+<body>
+<h1>Gaan Jasper & Pijke morgen winnen?</h1>
+
+<h2 class="prediction-title">Voorspelling van Morgen</h2>
+<div class="answer" id="answer">...</div>
+<div class="scoreboard" id="prediction_scoreboard">
+  <div class="row-wrapper">
+    <div class="team-label">Daan & Kors</div>
+    <div class="row" id="predicted_row1"></div>
+  </div>
+  <div class="row-wrapper">
+    <div class="team-label">Jasper & Pijke</div>
+    <div class="row" id="predicted_row2"></div>
+  </div>
+</div>
+<div id="tiebreak"></div>
+
+
+
+<canvas id="confetti-canvas"></canvas>
+
+<script>
+  // --- Standaard Confetti Logic ---
+  const confetti = {
+    canvas: null,
+    ctx: null,
+    particles: [],
+    colors: ["#ff595e", "#ffca3a", "#8ac926", "#1982c4", "#6a4c93"],
+    animationFrameId: null,
+    init() {
+      this.canvas = document.getElementById('confetti-canvas');
+      if (!this.canvas) {
+        console.error("Confetti canvas not found!");
+        return;
+      }
+      this.ctx = this.canvas.getContext('2d');
+      this.resizeCanvas(); // Initial resize
+      window.addEventListener('resize', () => this.resizeCanvas()); // Resize on window change
+    },
+    resizeCanvas() {
+      if (!this.canvas) return;
+      this.canvas.width = window.innerWidth;
+      this.canvas.height = window.innerHeight;
+    },
+    start() {
+      if (!this.ctx || !this.canvas) return;
+      this.particles = [];
+      for (let i = 0; i < 150; i++) {
+        this.particles.push(this.createParticle());
+      }
+      if (this.animationFrameId) {
+        cancelAnimationFrame(this.animationFrameId);
+      }
+      this.update();
+    },
+    createParticle() {
+      if (!this.canvas) return {};
+      return {
+        x: Math.random() * this.canvas.width,
+        y: Math.random() * -this.canvas.height * 0.5,
+        size: Math.random() * 8 + 2,
+        color: this.colors[Math.floor(Math.random() * this.colors.length)],
+        speedY: Math.random() * 2 + 1.5,
+        speedX: Math.random() * 2 - 1,
+        opacity: 1,
+        rotation: Math.random() * 360,
+        spin: (Math.random() - 0.5) * 10,
+      };
+    },
+    update() {
+      if (!this.ctx || !this.canvas) return;
+      this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+      let activeParticles = false;
+      this.particles.forEach((p) => {
+        p.y += p.speedY;
+        p.x += p.speedX;
+        p.rotation += p.spin;
+
+        if (p.y > this.canvas.height * 0.8) {
+          p.opacity -= 0.02;
+        }
+
+        if (p.opacity > 0 && p.y < this.canvas.height + p.size) {
+          activeParticles = true;
+          this.ctx.save();
+          this.ctx.translate(p.x + p.size / 2, p.y + p.size / 2);
+          this.ctx.rotate(p.rotation * Math.PI / 180);
+          this.ctx.fillStyle = p.color;
+          this.ctx.globalAlpha = p.opacity;
+          this.ctx.fillRect(-p.size/2, -p.size/2, p.size, p.size/2);
+          this.ctx.restore();
+        }
+      });
+
+      if (activeParticles) {
+        this.animationFrameId = requestAnimationFrame(() => this.update());
+      } else {
+        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.animationFrameId = null;
+      }
+    }
+  };
+
+  // --- Sukkels Confetti Logic ---
+  const sukkelsConfetti = {
+    canvas: null,
+    ctx: null,
+    particles: [],
+    image: new Image(),
+    imageLoaded: false,
+    animationFrameId: null,
+
+    init(imageSrc) { // imageSrc kan een pad zijn of een data URI
+      this.canvas = document.getElementById('confetti-canvas'); // Hergebruik hetzelfde canvas
+      if (!this.canvas) {
+        console.error("Sukkels Confetti: canvas not found!");
+        return;
+      }
+      this.ctx = this.canvas.getContext('2d');
+
+      this.image.onload = () => {
+        this.imageLoaded = true;
+        console.log("Sukkels afbeelding voor confetti geladen.");
+      };
+      this.image.onerror = () => {
+        console.error("Sukkels afbeelding voor confetti kon niet geladen worden. Controleer het pad/URL.");
+      };
+      this.image.src = imageSrc;
+    },
+    start() {
+      if (!this.ctx || !this.canvas) {
+        console.error("Sukkels Confetti: canvas context niet beschikbaar.");
+        return;
+      }
+      if (!this.imageLoaded) {
+        console.warn("Sukkels afbeelding nog niet geladen, confetti start niet. Probeert over 0.5s opnieuw als afbeelding dan geladen is.");
+        setTimeout(() => {
+          if(this.imageLoaded) this.start();
+        }, 500);
+        return;
+      }
+      this.particles = [];
+      // Verminder het aantal deeltjes van 50 naar 20
+      for (let i = 0; i < 20; i++) {
+        this.particles.push(this.createParticle());
+      }
+      if (this.animationFrameId) {
+        cancelAnimationFrame(this.animationFrameId);
+      }
+      this.update();
+    },
+    createParticle() {
+      if (!this.canvas) return {};
+      const imgAspectRatio = this.imageLoaded && this.image.width > 0 && this.image.height > 0 ? this.image.width / this.image.height : 1;
+      const baseSize = Math.random() * 120 + 90;
+
+      let particleWidth, particleHeight;
+      if (imgAspectRatio >= 1) {
+        particleWidth = baseSize;
+        particleHeight = baseSize / imgAspectRatio;
+      } else {
+        particleHeight = baseSize;
+        particleWidth = baseSize * imgAspectRatio;
+      }
+
+      return {
+        x: Math.random() * this.canvas.width,
+        y: Math.random() * -this.canvas.height * 0.5,
+        width: particleWidth,
+        height: particleHeight,
+        speedY: Math.random() * 2 + 1,
+        speedX: Math.random() * 2 - 1,
+        opacity: 1,
+        rotation: Math.random() * 360,
+        spin: (Math.random() - 0.5) * 5
+      };
+    },
+    update() {
+      if (!this.ctx || !this.canvas || !this.imageLoaded) return;
+      this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+      let activeParticles = false;
+      this.particles.forEach((p) => {
+        p.y += p.speedY;
+        p.x += p.speedX;
+        p.rotation += p.spin;
+
+        if (p.y > this.canvas.height * 0.9) {
+          p.opacity -= 0.03;
+        }
+
+        if (p.opacity > 0 && p.y < this.canvas.height + p.height) {
+          activeParticles = true;
+          this.ctx.save();
+          this.ctx.translate(p.x + p.width / 2, p.y + p.height / 2);
+          this.ctx.rotate(p.rotation * Math.PI / 180);
+          this.ctx.globalAlpha = p.opacity;
+          this.ctx.drawImage(this.image, -p.width / 2, -p.height / 2, p.width, p.height);
+          this.ctx.restore();
+        }
+      });
+
+      if (activeParticles) {
+        this.animationFrameId = requestAnimationFrame(() => this.update());
+      } else {
+        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.animationFrameId = null;
+      }
+    }
+  };
+
+
+  // --- Daily Prediction Logic ---
+  function getTomorrowKey() {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    return tomorrow.toISOString().split('T')[0];
+  }
+
+  function getDailyHash(input) {
+    let hash = 0;
+    for (let i = 0; i < input.length; i++) {
+      hash = (hash << 5) - hash + input.charCodeAt(i);
+      hash |= 0;
+    }
+    return Math.abs(hash);
+  }
+
+  function getDeterministicAnswer() {
+    const hash = getDailyHash(getTomorrowKey());
+    return hash % 2 === 0 ? 'Ja' : 'Nee';
+  }
+
+  function generateSingleSetScore(answer) {
+    const base = getDailyHash(getTomorrowKey() + "_set_prediction");
+    const outcomes = [
+      [6,0], [6,1], [6,2], [6,3], [6,4],
+      [7,5], [7,6]
+    ];
+    const index = base % outcomes.length;
+    let [scoreTeam1, scoreTeam2] = outcomes[index];
+
+    const pijkeJasperWin = (answer === 'Ja');
+
+    const scorePijkeJasper = pijkeJasperWin ? scoreTeam1 : scoreTeam2;
+    const scoreDaanKors = pijkeJasperWin ? scoreTeam2 : scoreTeam1;
+
+    let tiebreakDetails = null;
+    if ((scorePijkeJasper === 7 && scoreDaanKors === 6) || (scoreDaanKors === 7 && scorePijkeJasper === 6)) {
+      const tiebreakBase = getDailyHash(getTomorrowKey() + "_tiebreak_prediction");
+      const tiebreakPointsWinner = 7 + (tiebreakBase % 4);
+      let tiebreakPointsLoser;
+      if (tiebreakPointsWinner === 7) {
+        tiebreakPointsLoser = (tiebreakBase % 5);
+      } else {
+        tiebreakPointsLoser = tiebreakPointsWinner - 2;
+      }
+      tiebreakPointsLoser = Math.max(0, Math.min(tiebreakPointsLoser, tiebreakPointsWinner - 2));
+      tiebreakDetails = pijkeJasperWin ? `${tiebreakPointsWinner}–${tiebreakPointsLoser}` : `${tiebreakPointsLoser}–${tiebreakPointsWinner}`;
+    }
+    return { scoreA: scoreDaanKors, scoreB: scorePijkeJasper, tiebreak: tiebreakDetails };
+  }
+
+  function displayBeads(rowElementId, score) {
+    const rowElement = document.getElementById(rowElementId);
+    if (!rowElement) {
+      console.error(`Element with ID ${rowElementId} not found.`);
+      return;
+    }
+    rowElement.innerHTML = '';
+    const scoreNum = Number(score);
+    const validScore = isNaN(scoreNum) ? 0 : scoreNum;
+
+    for (let i = 0; i < validScore; i++) {
+      const bead = document.createElement('div');
+      bead.className = 'bead';
+      rowElement.appendChild(bead);
+    }
+  }
+
+  function generatePredictedGame() {
+    const answer = getDeterministicAnswer();
+    document.getElementById('answer').textContent = answer;
+
+    const { scoreA, scoreB, tiebreak } = generateSingleSetScore(answer);
+
+    displayBeads('predicted_row1', scoreA);
+    displayBeads('predicted_row2', scoreB);
+
+    const tiebreakEl = document.getElementById('tiebreak');
+    tiebreakEl.textContent = tiebreak ? `(Voorspelde Tiebreak: ${tiebreak})` : '';
+
+    if (confetti.animationFrameId) {
+      cancelAnimationFrame(confetti.animationFrameId);
+      confetti.animationFrameId = null;
+      if (confetti.ctx && confetti.canvas) confetti.ctx.clearRect(0, 0, confetti.canvas.width, confetti.canvas.height);
+    }
+    if (sukkelsConfetti.animationFrameId) {
+      cancelAnimationFrame(sukkelsConfetti.animationFrameId);
+      sukkelsConfetti.animationFrameId = null;
+      if (sukkelsConfetti.ctx && sukkelsConfetti.canvas) sukkelsConfetti.ctx.clearRect(0, 0, sukkelsConfetti.canvas.width, sukkelsConfetti.canvas.height);
+    }
+
+    if (answer === 'Ja') {
+      if (scoreA === 0 && scoreB === 6) {
+        sukkelsConfetti.start();
+      } else {
+        confetti.start();
+      }
+    }
+  }
+
+  // --- Initialize Page ---
+  document.addEventListener('DOMContentLoaded', () => {
+    // const placeholderSukkelsSVG = `data:image/svg+xml;charset=utf-8,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="40" height="40"><path d="M50,8C26.8,8,8,26.8,8,50s18.8,42,42,42s42-18.8,42-42S73.2,8,50,8z M50,88C28.9,88,12,71.1,12,50S28.9,12,50,12s38,16.9,38,38S71.1,88,50,88z" fill="#795548"/><path d="M70.3,62.2c-2.2-2.2-5.1-3.4-8.2-3.4H37.9c-3.1,0-6,1.3-8.2,3.4c-1.2,1.2-1.8,2.7-1.8,4.4c0,2.3,1.2,4.4,3.1,5.8 C33.2,74,36.4,75,40,75h20c3.6,0,6.8-1,9-2.6c1.9-1.3,3.1-3.4,3.1-5.8C72.1,64.9,71.5,63.4,70.3,62.2z" fill="#A1887F"/><ellipse cx="38" cy="43" rx="6" ry="8" fill="#FFFFFF"/><ellipse cx="62" cy="43" rx="6" ry="8" fill="#FFFFFF"/><circle cx="38" cy="43" r="3" fill="#000000"/><circle cx="62" cy="43" r="3" fill="#000000"/><path d="M50,70c-8.3,0-15-6.7-15-15h30C65,63.3,58.3,70,50,70z" fill="#FFFFFF"/><path d="M50,68c-7.2,0-13-5.8-13-13h26C63,62.2,57.2,68,50,68z" fill="#E57373"/></svg>')}`;
+    // BELANGRIJK: Als je 'sukkels.png' lokaal gebruikt, vervang placeholderSukkelsSVG hierboven met het pad, bijv.:
+    const afbeeldingVoorSukkelsConfetti = 'sukkels.png';
+    sukkelsConfetti.init(afbeeldingVoorSukkelsConfetti);
+    // Anders, als je de SVG placeholder wilt blijven gebruiken:
+    // sukkelsConfetti.init(placeholderSukkelsSVG);
+
+    confetti.init();
+    generatePredictedGame();
+  });
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove the combined forecast endpoint
- add `/api/forecast/today/` with today's deterministic prediction
- add `/api/forecast/tomorrow/` with tomorrow's deterministic prediction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875023849548325ac035fbbe3b6f11b