### PR TITLE
Use deterministic forecast logic for API and streamline JSON

### DIFF
--- a/api/forecast/today.html
+++ b/api/forecast/today.html
@@ -8,16 +8,27 @@
   <pre id="data"></pre>
   <script>
     (function() {
-      const now = new Date();
-      const dayOfWeek = now.getDay();
-      const hour = now.getHours();
-      const seed = dayOfWeek * 24 + hour;
-      const prediction = seed % 2 === 0 ? 'ja' : 'nee';
+      function getTodayKey() {
+        const today = new Date();
+        return today.toISOString().split('T')[0];
+      }
+
+      function getDailyHash(input) {
+        let hash = 0;
+        for (let i = 0; i < input.length; i++) {
+          hash = (hash << 5) - hash + input.charCodeAt(i);
+          hash |= 0;
+        }
+        return Math.abs(hash);
+      }
+
+      function getDeterministicAnswer() {
+        const hash = getDailyHash(getTodayKey());
+        return hash % 2 === 0 ? 'Ja' : 'Nee';
+      }
+
       const output = {
-        "vraag": "Gaan Jasper & Pijke winnen?",
-        "voorspelling": prediction,
-        "moment": "today",
-        "timestamp": now.toISOString()
+        "gaanjasperenpijkevandaagwinnen": getDeterministicAnswer()
       };
       document.getElementById('data').textContent = JSON.stringify(output, null, 2);
     })();

--- a/api/forecast/tomorrow.html
+++ b/api/forecast/tomorrow.html
@@ -8,16 +8,28 @@
   <pre id="data"></pre>
   <script>
     (function() {
-      const now = new Date(Date.now() + 24 * 60 * 60 * 1000);
-      const dayOfWeek = now.getDay();
-      const hour = now.getHours();
-      const seed = dayOfWeek * 24 + hour;
-      const prediction = seed % 2 === 0 ? 'ja' : 'nee';
+      function getTomorrowKey() {
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 1);
+        return tomorrow.toISOString().split('T')[0];
+      }
+
+      function getDailyHash(input) {
+        let hash = 0;
+        for (let i = 0; i < input.length; i++) {
+          hash = (hash << 5) - hash + input.charCodeAt(i);
+          hash |= 0;
+        }
+        return Math.abs(hash);
+      }
+
+      function getDeterministicAnswer() {
+        const hash = getDailyHash(getTomorrowKey());
+        return hash % 2 === 0 ? 'Ja' : 'Nee';
+      }
+
       const output = {
-        "vraag": "Gaan Jasper & Pijke winnen?",
-        "voorspelling": prediction,
-        "moment": "tomorrow",
-        "timestamp": now.toISOString()
+        "gaanjasperenpijkemorgenwinnen": getDeterministicAnswer()
       };
       document.getElementById('data').textContent = JSON.stringify(output, null, 2);
     })();


### PR DESCRIPTION
## Summary
- Align vandaag and morgen API endpoints with website's deterministic hash calculation
- Simplify API responses to a single yes/no field for each day

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899dc3e798483259646c5e56134fabc